### PR TITLE
Replace pycrypto with pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
     keywords='cryptography pki x509 smime email pdf pkcs11 asn1 xades',
     packages=find_packages(exclude=['examples',]),
     platforms=["all"],
-    install_requires=['pycrypto', 'asn1crypto', 'pyopenssl', 'pdfminer.six', 'lxml', 'pykcs11'],
+    install_requires=['pycryptodome', 'asn1crypto', 'pyopenssl', 'pdfminer.six', 'lxml', 'pykcs11'],
 )


### PR DESCRIPTION
This replaces `pycrypto` requirement with `pycryptodome`. It is a drop-in replacement for `pycrypto` which is not actively maintained and has a known vulnerability, `CVE-2013-7459`. Moreover, one of the requirements of this package, `pdfminer.six` depends on `pycryptodome`, and `pycryptodome` conflicts with `pycrypto`, so these packages will interfere when they are installed simultaneously. All examples have been tested and run without errors