### PR TITLE
Throw exception when timestamp is invalid

### DIFF
--- a/endesive/signer.py
+++ b/endesive/signer.py
@@ -191,6 +191,12 @@ def sign(datau, key, cert, othercerts, hashalgo, attrs=True, signed_value=None, 
                 ]
                 datas['content']['signer_infos'][0]['unsigned_attrs'] = attrs
 
+            else:
+                raise ValueError("TimeStampResponse status is not granted")
+
+        else:
+            raise ValueError("TimeStampResponse has invalid content type")
+
     # signed_value_signature = core.OctetString(signed_value_signature)
     datas['content']['signer_infos'][0]['signature'] = signed_value_signature
 


### PR DESCRIPTION
If the timestamp is invalid, now the error is not detected because it succeeds silently.

In this pull request, I throw an exception when the timestamp response is invalid.
