### PR TITLE
Add support for signing existing form fields, configured using 'signform'

### DIFF
--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -391,13 +391,24 @@ class SignedData(pdf.PdfFileWriter):
                         }
                     )
                     break
+            
+            old_flags = int(form.get("/SigFlags", 0))
+            new_flags = int(form.get("/SigFlags", 0)) | udct.get("sigflags", 3)
             if new_13:
                 fields.append(obj13ref)
                 form.update(
                     {
                         po.NameObject("/Fields"): fields,
                         po.NameObject("/SigFlags"): po.NumberObject(
-                            udct.get("sigflags", 3)
+                            new_flags
+                        ),
+                    }
+                )
+            elif new_flags > old_flags:
+                form.update(
+                    {
+                        po.NameObject("/SigFlags"): po.NumberObject(
+                            new_flags
                         ),
                     }
                 )


### PR DESCRIPTION
Another case I wanted to be able to handle: signing a form with an existing signature field.  It doesn't check for any pre-existing signature associated with the field at the moment or the uncommon case of SigAnnot and SigField being separate dictionaries.  udct keys necessary for use:
 * signform
 * sigfield
 * signature, signature_img, (or if you peek in another of my branches, signature_annot)
It ignores signaturebox, favouring the /Rect from the SigAnnot.  If signature_img is used, the image is stretched to fill the annotation, whilst the text from signature is simply left-aligned in the annotation.