### PR TITLE
Signature annotation

### DIFF
--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -311,7 +311,12 @@ class SignedData(pdf.PdfFileWriter):
                 # Simple image signature, stretches to fit the box
                 # image to render is contained in udct['signature_image']
                 annotation.add_image(udct["signature_img"], "Image")
-                annotation.set_signature_appearance(['image', "Image", 0, 0, x2-x1, y2-y1])
+                annotation.set_signature_appearance(
+                    ['image', "Image", 0, 0, x2-x1, y2-y1,
+                        udct.get('signature_img_distort', True),
+                        udct.get('signature_img_centred', False),
+                        ]
+                    )
             elif 'signature_appearance' in udct:
                 # Adobe-inspired signature with text and images
                 # Parameters are contained in udct['signature_appearance']
@@ -686,6 +691,19 @@ def sign(
                                                     pil image instance or
                                                     image file name or
                                                     byte array of image
+            signature_img_distort: bool default:True
+                                                True  - do not maintain image aspect ratio, fill the
+                                                        entire bounding box, distorting the image.
+                                                        This is set to True to match the behaviour
+                                                        of previous versions of endesive
+                                                False - maintain image aspect ratio when fitting
+                                                        image into the bounding box
+            signature_img_centred: bool default:True
+                                                True  - centre images within the bounding box when
+                                                        image aspect ratio does not match that of
+                                                        the bounding box
+                                                False - do not centre image, position it at the
+                                                        lower-left of the bounding box
             signature_appearance: dict  if box is not None then render a signature appearance that is
                                             configured by the dict.  See below for configuration
             signature_manual: list      if box is not None then render a manually-created signature

--- a/examples/document_signing/pdf-sign-cms-existing-field.py
+++ b/examples/document_signing/pdf-sign-cms-existing-field.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env vpython3
+# *-* coding: utf-8 *-*
+import sys
+import datetime
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from endesive.pdf import cms
+
+# from endesive.pdf import cmsn as cms
+
+# import logging
+# logging.basicConfig(level=logging.DEBUG)
+
+
+def main():
+    date = datetime.datetime.utcnow() - datetime.timedelta(hours=12)
+    date = date.strftime("D:%Y%m%d%H%M%S+00'00'")
+    dct = {
+        "aligned": 0,
+        "sigflags": 3,
+        "sigflagsft": 132,
+        "sigpage": 0,
+        #"auto_sigfield": False,
+        #"sigandcertify": False,
+        #"signaturebox": (0, 0, 590, 155),
+        "signform": True,
+        "sigfield": "Signature",
+        "signature_manual": [
+            #                R     G     B
+            ['fill_colour', 0.95, 0.95, 0.95],
+
+            #            *[bounding box]
+            ['rect_fill', 0, 0, 270, 18],
+
+            #                  R    G    B
+            ['stroke_colour', 0.8, 0.8, 0.8],
+
+            #          key  *[bounding box]
+            ['image', 'sig0', 0, 0, 59, 15],
+
+            #        inset
+            ['border', 2],
+
+            #         font     fs 
+            ['font', 'default', 7],
+            #               R  G  B
+            ['fill_colour', 0, 0, 0],
+
+            #            text
+            ['text_box', 'signed using endesive\ndate: {}'.format(date),
+                # font  *[bounding box], fs, wrap, align, baseline
+                'default', 0, 2, 270, 18, 7, True, 'right', 'top'],
+            ],
+        #   key: name used in image directives
+        # value: PIL Image object or path to image file
+        "manual_images": {'sig0': '../signature_test.png'},
+        #   key: name used in font directives
+        # value: path to TTF Font file
+        "manual_fonts": {},
+
+        "contact": "mak@trisoft.com.pl",
+        "location": "Szczecin",
+        "signingdate": date,
+        "reason": "Dokument podpisany cyfrowo aą cć eę lł nń oó sś zż zź",
+        "password": "1234",
+    }
+    with open("demo2_user1.p12", "rb") as fp:
+        p12 = pkcs12.load_key_and_certificates(
+            fp.read(), b"1234", backends.default_backend()
+        )
+    fname = "../pdf_forms/blank_form.pdf"
+    if len(sys.argv) > 1:
+        fname = sys.argv[1]
+    datau = open(fname, "rb").read()
+    datas = cms.sign(datau, dct, p12[0], p12[1], p12[2], "sha256")
+    fname = fname.replace(".pdf", "-signed-cms.pdf")
+    with open(fname, "wb") as fp:
+        fp.write(datau)
+        fp.write(datas)
+
+
+main()

--- a/examples/pdf_forms/blank_form.pdf
+++ b/examples/pdf_forms/blank_form.pdf
@@ -1,0 +1,146 @@
+%PDF-1.3
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<</Type /Encoding /Differences [24 /breve /caron /circumflex /dotaccent /hungarumlaut /ogonek /ring /tilde 39 /quotesingle 96 /grave 128 /bullet /dagger /daggerdbl /ellipsis /emdash /endash /florin /fraction /guilsinglleft /guilsinglright /minus /perthousand /quotedblbase /quotedblleft /quotedblright /quoteleft /quoteright /quotesinglbase /trademark /fi /fl /Lslash /OE /Scaron /Ydieresis /Zcaron /dotlessi /lslash /oe /scaron /zcaron 160 /Euro 164 /currency 166 /brokenbar 168 /dieresis /copyright /ordfeminine 172 /logicalnot /.notdef /registered /macron /degree /plusminus /twosuperior /threesuperior /acute /mu 183 /periodcentered /cedilla /onesuperior /ordmasculine 188 /onequarter /onehalf /threequarters 192 /Agrave /Aacute /Acircumflex /Atilde /Adieresis /Aring /AE /Ccedilla /Egrave /Eacute /Ecircumflex /Edieresis /Igrave /Iacute /Icircumflex /Idieresis /Eth /Ntilde /Ograve /Oacute /Ocircumflex /Otilde /Odieresis /multiply /Oslash /Ugrave /Uacute /Ucircumflex /Udieresis /Yacute /Thorn /germandbls /agrave /aacute /acircumflex /atilde /adieresis /aring /ae /ccedilla /egrave /eacute /ecircumflex /edieresis /igrave /iacute /icircumflex /idieresis /eth /ntilde /ograve /oacute /ocircumflex /otilde /odieresis /divide /oslash /ugrave /uacute /ucircumflex /udieresis /yacute /thorn /ydieresis]>>
+endobj
+5 0 obj
+<< /BaseFont /Helvetica /Subtype /Type1 /Name /Helv /Type /Font /Encoding 4 0 R >>
+endobj
+6 0 obj
+<<
+/BBox [ 0 0 270 18 ] /Filter [ /FlateDecode ] /FormType 1 /Length 112 /Matrix [ 1 0 0 1 0 0 ] /Resources << /ProcSet [/PDF /Text] /Font <</Helv 5 0 R>> >> 
+  /Subtype /Form /Type /XObject
+>>
+stream
+xœ%Œ1
+Â@DûwŠ)µIþ.qÅ6!Ä&…òÁ"‚Ôã»«oš7ŒÉrŽAo¬Ú¨Ó®2…m®eâIíµc'Då¤Ttó×'î˜æÌ@ëÔûéöRˆòö;_f•±ŸY­åWzç@?v|TVöendstream
+endobj
+7 0 obj
+<<
+/AP <<
+/N 6 0 R
+>> /BS <<
+/S /S /W 1
+>> /DA (/Helv 12 Tf 0 0 0 rg) /DV () /F 0 /FT /Tx 
+  /Ff 0 /MK <<
+/BC [ 0 0 0 ] /BG [  ]
+>> /P 11 0 R /Rect [ 306 504 576 522 ] /Subtype /Widget /T (Name) 
+  /Type /Annot /V ()
+>>
+endobj
+8 0 obj
+<< /BaseFont /Helvetica /Subtype /Type1 /Name /Helv /Type /Font /Encoding 4 0 R >>
+endobj
+9 0 obj
+<<
+/BBox [ 0 0 270 18 ] /Filter [ /FlateDecode ] /FormType 1 /Length 112 /Matrix [ 1 0 0 1 0 0 ] /Resources << /ProcSet [/PDF /Text] /Font <</Helv 8 0 R>> >> 
+  /Subtype /Form /Type /XObject
+>>
+stream
+xœ%Œ1
+Â@DûwŠ)µIþ.qÅ6!Ä&…òÁ"‚Ôã»«oš7ŒÉrŽAo¬Ú¨Ó®2…m®eâIíµc'Då¤Ttó×'î˜æÌ@ëÔûéöRˆòö;_f•±ŸY­åWzç@?v|TVöendstream
+endobj
+10 0 obj
+<<
+/FT /Sig 
+/Type /Annot
+/Subtype /Widget
+/F 4
+/T (Signature) 
+/Rect [ 306 486 576 504 ]
+/P 11 0 R
+/AP << /N 9 0 R >>
+>>
+endobj
+11 0 obj
+<<
+/Annots [ 7 0 R 10 0 R ] /Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/AcroForm 16 0 R /PageMode /UseNone /Pages 14 0 R /Type /Catalog
+>>
+endobj
+13 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20210307160844+05'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20210307160844+05'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+14 0 obj
+<<
+/Count 1 /Kids [ 11 0 R ] /Type /Pages
+>>
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 184
+>>
+stream
+Gat&EYmu@>&-h'`Vt`c)W4gVWAeT8@%!jQlZku>k$)#Tt\Mu9VP[&7Hjo<(85u0kR0+lhk[X/&nE"0+qJr_<>Oh:F6V`/%3W\QQ#K-OD:L(X*lO)&\BhY`@XA`0X*V!+siBV&Y3+cg:e7Tm^,rR=VkRqL/62n,q.+8m2,Ousc!C-Mek?DC4n1&~>endstream
+endobj
+16 0 obj
+<<
+/DA (/Helv 0 Tf 0 g) /DR << /Encoding
+<<
+/RLAFencoding
+4 0 R
+>>
+/Font << /Helv 5 0 R >>
+>> /Fields [ 7 0 R 10 0 R ]
+/SigFlags 1
+>>
+endobj
+xref
+0 17
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000326 00000 n 
+0000001648 00000 n 
+0000001746 00000 n 
+0000002084 00000 n 
+0000002319 00000 n 
+0000002417 00000 n 
+0000002755 00000 n 
+0000002893 00000 n 
+0000003114 00000 n 
+0000003201 00000 n 
+0000003498 00000 n 
+0000003559 00000 n 
+0000003834 00000 n 
+trailer
+<<
+/ID 
+[<e78b8f250a780f9235e293fdab723d6d><e78b8f250a780f9235e293fdab723d6d>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 13 0 R
+/Root 12 0 R
+/Size 17
+>>
+startxref
+3984
+%%EOF

--- a/examples/signature_appearances/signature.py
+++ b/examples/signature_appearances/signature.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env vpython3
+# *-* coding: utf-8 *-*
+import sys
+import datetime
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from endesive.pdf import cms
+
+# from endesive.pdf import cmsn as cms
+
+# import logging
+# logging.basicConfig(level=logging.DEBUG)
+
+
+def main():
+    date = datetime.datetime.utcnow() - datetime.timedelta(hours=12)
+    date = date.strftime("D:%Y%m%d%H%M%S+00'00'")
+    dct = {
+        "aligned": 0,
+        "sigflags": 3,
+        "sigflagsft": 132,
+        "sigpage": 0,
+        #"auto_sigfield": False,
+        #"sigandcertify": False,
+        #"signaturebox": (0, 0, 590, 155),
+        "signform": True,
+        "sigfield": "Signature",
+        #             Text will be in the default font
+        "signature": 'Signed field!',
+
+        # default configuration for the text appearance
+        "text": {
+            'wraptext': True,
+            'fontsize': 12,
+            'textalign': 'left',
+            'linespacing': 1.2,
+            },
+
+        "contact": "mak@trisoft.com.pl",
+        "location": "Szczecin",
+        "signingdate": date,
+        "reason": "Dokument podpisany cyfrowo aą cć eę lł nń oó sś zż zź",
+        "password": "1234",
+    }
+    with open("../demo2_user1.p12", "rb") as fp:
+        p12 = pkcs12.load_key_and_certificates(
+            fp.read(), b"1234", backends.default_backend()
+        )
+    fname = "../pdf_forms/blank_form.pdf"
+    if len(sys.argv) > 1:
+        fname = sys.argv[1]
+    datau = open(fname, "rb").read()
+    datas = cms.sign(datau, dct, p12[0], p12[1], p12[2], "sha256")
+    fname = fname.replace(".pdf", "-signature.pdf")
+    with open(fname, "wb") as fp:
+        fp.write(datau)
+        fp.write(datas)
+
+
+main()

--- a/examples/signature_appearances/signature_appearance.py
+++ b/examples/signature_appearances/signature_appearance.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env vpython3
+# *-* coding: utf-8 *-*
+import sys
+import datetime
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from endesive.pdf import cms
+
+# from endesive.pdf import cmsn as cms
+
+# import logging
+# logging.basicConfig(level=logging.DEBUG)
+
+
+def main():
+    date = datetime.datetime.utcnow() - datetime.timedelta(hours=12)
+    date = date.strftime("D:%Y%m%d%H%M%S+00'00'")
+    dct = {
+        "aligned": 0,
+        "sigflags": 3,
+        "sigflagsft": 132,
+        "sigpage": 0,
+        "auto_sigfield": True,
+        #"sigandcertify": False,
+        "signaturebox": (72, 396, 360, 468),
+        "signform": False,
+        "sigfield": "Signature",
+
+        # Text will be in the default font
+        # Fields in the list display will be included in the text listing
+        # Icon and background can both be set to images by having their
+        #   value be a path to a file or a PIL Image object
+        # If background is a list it is considered to be an opaque RGB colour
+        # Outline is the colour used to draw both the border and the text
+        "signature_appearance": {
+            'background': [0.75, 0.8, 0.95],
+            'icon': '../signature_test.png',
+            'outline': [0.2, 0.3, 0.5],
+            'border': 2,
+            'labels': True,
+            'display': 'CN,DN,date,contact,reason,location'.split(','),
+            },
+
+        "contact": "mak@trisoft.com.pl",
+        "location": "Szczecin",
+        "signingdate": date,
+        "reason": "Dokument podpisany cyfrowo aą cć eę lł nń oó sś zż zź",
+        "password": "1234",
+    }
+    with open("../demo2_user1.p12", "rb") as fp:
+        p12 = pkcs12.load_key_and_certificates(
+            fp.read(), b"1234", backends.default_backend()
+        )
+    fname = "../pdf_forms/blank_form.pdf"
+    if len(sys.argv) > 1:
+        fname = sys.argv[1]
+    datau = open(fname, "rb").read()
+    datas = cms.sign(datau, dct, p12[0], p12[1], p12[2], "sha256")
+    fname = fname.replace(".pdf", "-signature_appearance.pdf")
+    with open(fname, "wb") as fp:
+        fp.write(datau)
+        fp.write(datas)
+
+
+main()

--- a/examples/signature_appearances/signature_img.py
+++ b/examples/signature_appearances/signature_img.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env vpython3
+# *-* coding: utf-8 *-*
+import sys
+import datetime
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from endesive.pdf import cms
+
+# from endesive.pdf import cmsn as cms
+
+# import logging
+# logging.basicConfig(level=logging.DEBUG)
+
+
+def main():
+    date = datetime.datetime.utcnow() - datetime.timedelta(hours=12)
+    date = date.strftime("D:%Y%m%d%H%M%S+00'00'")
+    dct = {
+        "aligned": 0,
+        "sigflags": 3,
+        "sigflagsft": 132,
+        "sigpage": 0,
+        #"auto_sigfield": False,
+        #"sigandcertify": False,
+        #"signaturebox": (0, 0, 590, 155),
+        "signform": True,
+        "sigfield": "Signature",
+        #                PIL Image object or path to image file
+        #                Image will be resized to fit bounding box
+        "signature_img": '../signature_test.png',
+
+        "contact": "mak@trisoft.com.pl",
+        "location": "Szczecin",
+        "signingdate": date,
+        "reason": "Dokument podpisany cyfrowo aą cć eę lł nń oó sś zż zź",
+        "password": "1234",
+    }
+    with open("../demo2_user1.p12", "rb") as fp:
+        p12 = pkcs12.load_key_and_certificates(
+            fp.read(), b"1234", backends.default_backend()
+        )
+    fname = "../pdf_forms/blank_form.pdf"
+    if len(sys.argv) > 1:
+        fname = sys.argv[1]
+    datau = open(fname, "rb").read()
+    datas = cms.sign(datau, dct, p12[0], p12[1], p12[2], "sha256")
+    fname = fname.replace(".pdf", "-signature_img.pdf")
+    with open(fname, "wb") as fp:
+        fp.write(datau)
+        fp.write(datas)
+
+
+main()

--- a/examples/signature_appearances/signature_img.py
+++ b/examples/signature_appearances/signature_img.py
@@ -29,6 +29,8 @@ def main():
         #                PIL Image object or path to image file
         #                Image will be resized to fit bounding box
         "signature_img": '../signature_test.png',
+        "signature_img_distort": False, # default True
+        "signature_img_centred": False, # default True
 
         "contact": "mak@trisoft.com.pl",
         "location": "Szczecin",

--- a/examples/signature_appearances/signature_manual.py
+++ b/examples/signature_appearances/signature_manual.py
@@ -36,11 +36,11 @@ def main():
             #                  R    G    B
             ['stroke_colour', 0.8, 0.8, 0.8],
 
-            #          key  *[bounding box]  distort centred
-            ['image', 'sig0', 0, 0, 270, 18,  False, False],
-
             #        inset
             ['border', 2],
+
+            #          key  *[bounding box]  distort centred
+            ['image', 'sig0', 0, 0, 270, 18,  False, False],
 
             #         font     fs 
             ['font', 'default', 7],

--- a/examples/signature_appearances/signature_manual.py
+++ b/examples/signature_appearances/signature_manual.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env vpython3
+# *-* coding: utf-8 *-*
+import sys
+import datetime
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives.serialization import pkcs12
+
+from endesive.pdf import cms
+
+# from endesive.pdf import cmsn as cms
+
+# import logging
+# logging.basicConfig(level=logging.DEBUG)
+
+
+def main():
+    date = datetime.datetime.utcnow() - datetime.timedelta(hours=12)
+    date = date.strftime("D:%Y%m%d%H%M%S+00'00'")
+    dct = {
+        "aligned": 0,
+        "sigflags": 3,
+        "sigflagsft": 132,
+        "sigpage": 0,
+        #"auto_sigfield": False,
+        #"sigandcertify": False,
+        #"signaturebox": (0, 0, 590, 155),
+        "signform": True,
+        "sigfield": "Signature",
+        "signature_manual": [
+            #                R     G     B
+            ['fill_colour', 0.95, 0.95, 0.95],
+
+            #            *[bounding box]
+            ['rect_fill', 0, 0, 270, 18],
+
+            #                  R    G    B
+            ['stroke_colour', 0.8, 0.8, 0.8],
+
+            #          key  *[bounding box]
+            ['image', 'sig0', 0, 0, 59, 15],
+
+            #        inset
+            ['border', 2],
+
+            #         font     fs 
+            ['font', 'default', 7],
+            #               R  G  B
+            ['fill_colour', 0, 0, 0],
+
+            #            text
+            ['text_box', 'signed using endesive\ndate: {}'.format(date),
+                # font  *[bounding box], fs, wrap, align, baseline
+                'default', 0, 2, 270, 18, 7, True, 'right', 'top'],
+            ],
+        #   key: name used in image directives
+        # value: PIL Image object or path to image file
+        "manual_images": {'sig0': '../signature_test.png'},
+        #   key: name used in font directives
+        # value: path to TTF Font file
+        "manual_fonts": {},
+
+        "contact": "mak@trisoft.com.pl",
+        "location": "Szczecin",
+        "signingdate": date,
+        "reason": "Dokument podpisany cyfrowo aą cć eę lł nń oó sś zż zź",
+        "password": "1234",
+    }
+    with open("../demo2_user1.p12", "rb") as fp:
+        p12 = pkcs12.load_key_and_certificates(
+            fp.read(), b"1234", backends.default_backend()
+        )
+    fname = "../pdf_forms/blank_form.pdf"
+    if len(sys.argv) > 1:
+        fname = sys.argv[1]
+    datau = open(fname, "rb").read()
+    datas = cms.sign(datau, dct, p12[0], p12[1], p12[2], "sha256")
+    fname = fname.replace(".pdf", "-signature_manual.pdf")
+    with open(fname, "wb") as fp:
+        fp.write(datau)
+        fp.write(datas)
+
+
+main()

--- a/examples/signature_appearances/signature_manual.py
+++ b/examples/signature_appearances/signature_manual.py
@@ -36,8 +36,8 @@ def main():
             #                  R    G    B
             ['stroke_colour', 0.8, 0.8, 0.8],
 
-            #          key  *[bounding box]
-            ['image', 'sig0', 0, 0, 59, 15],
+            #          key  *[bounding box]  distort centred
+            ['image', 'sig0', 0, 0, 270, 18,  False, False],
 
             #        inset
             ['border', 2],


### PR DESCRIPTION
Here are some examples using the different signature annotations.  I also added some options for signature_img and the manual image directive to allow for maintaining the image aspect ratio.  I made sure to include plenty of text inside the examples.

I created the document that my examples sign, blank_form.pdf, by first creating a small form using ReportLab, that I then manually edited to create a proper empty signature field.