### PR TITLE
Fix new field name generation if it already exists

### DIFF
--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -553,7 +553,7 @@ class SignedData(pdf.PdfFileWriter):
                 for i in range(1, len(checklist) + 1):
                     suffix = "_{}".format(i)
                     if suffix in checklist:
-                        next
+                        continue
 
                     new_name = "{}{}".format(name_base, suffix)
                     obj13.update({po.NameObject("/T"): EncodedString(new_name)})
@@ -980,4 +980,3 @@ def sign(
         ocspurl,
         ocspissuer,
     )
-


### PR DESCRIPTION
Hi everyone!
I have found a small issue with 
It happens when a document was signed more than 3 times with settings `"sigfield": "Signature", "auto_sigfield": True,`
I can also provide a test case if it is necessary.