### PR TITLE
fix: unitialized array in systemCertsPath branch

### DIFF
--- a/endesive/verifier.py
+++ b/endesive/verifier.py
@@ -23,6 +23,8 @@ class VerifyData(object):
                     _, _, cert_bytes = pem.unarmor(cert_bytes)
                 certs.append(x509.Certificate.load(cert_bytes))
         if systemCertsPath is not None:
+            if not certs:
+                certs = []
             for fname in glob.glob(os.path.join(systemCertsPath, "*.pem")):
                 with open(fname, "rb") as fp:
                     cert_bytes = fp.read()


### PR DESCRIPTION
Hello,

This pull request fixes a problem in the `__init__` method of the `VerifyData` class.

If the parameter `trustedCerts` is not used the variable `certs` is still `None`.
If some `systemCertsPath` are submitted trying to `append` to the variable causes an error.
The solution is to check if the variable has been initialized before.
If not, set `certs` to an empty array.