### PR TITLE
Read PDF should not raise errors

### DIFF
--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -636,7 +636,7 @@ class SignedData(pdf.PdfFileWriter):
         fi = io.BytesIO(datau)
 
         # read end decrypt
-        prev = pdf.PdfFileReader(fi)
+        prev = pdf.PdfFileReader(fi, strict=False)
         if prev.isEncrypted:
             rc = prev.decrypt(udct["password"])
         else:


### PR DESCRIPTION
Many PDFs don't exactly follow the specifications but can still be opened by readers, so we shouldn't be too strict about that when signing.

References: https://pypdf2.readthedocs.io/en/latest/user/robustness.html