### PR TITLE
use LIBDIR from sysconfig

### DIFF
--- a/examples/cert-info-hsm.py
+++ b/examples/cert-info-hsm.py
@@ -4,8 +4,7 @@ import sys
 from endesive import pdf, hsm
 
 import os
-import sys
-import datetime
+import sysconfig
 
 os.environ['SOFTHSM2_CONF'] = 'softhsm2.conf'
 if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2.conf')):
@@ -28,7 +27,7 @@ if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2')):
 if sys.platform == 'win32':
     dllpath = r'W:\binw\SoftHSM2\lib\softhsm2-x64.dll'
 else:
-    dllpath = '/usr/lib/softhsm/libsofthsm2.so'
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 import PyKCS11 as PK11
 

--- a/examples/cert-make-hsm.py
+++ b/examples/cert-make-hsm.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import sysconfig
 
 os.environ['SOFTHSM2_CONF'] = 'softhsm2.conf'
 if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2.conf')):
@@ -25,7 +26,7 @@ if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2')):
 if sys.platform == 'win32':
     dllpath = r'W:\binw\SoftHSM2\lib\softhsm2-x64.dll'
 else:
-    dllpath = '/usr/lib/softhsm/libsofthsm2.so'
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 from endesive import hsm
 import PyKCS11 as PK11

--- a/examples/pdf-sign-cms-hash-sign.py
+++ b/examples/pdf-sign-cms-hash-sign.py
@@ -7,8 +7,7 @@ from asn1crypto import pem as asn1pem
 from endesive import hsm
 
 import os
-import sys
-import datetime
+import sysconfig
 
 os.environ["SOFTHSM2_CONF"] = "softhsm2.conf"
 if not os.path.exists(os.path.join(os.getcwd(), "softhsm2.conf")):
@@ -34,7 +33,7 @@ if not os.path.exists(os.path.join(os.getcwd(), "softhsm2")):
 if sys.platform == "win32":
     dllpath = r"W:\binw\SoftHSM2\lib\softhsm2-x64.dll"
 else:
-    dllpath = "/usr/lib/softhsm/libsofthsm2.so"
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 import PyKCS11 as PK11
 

--- a/examples/pdf-sign-cms-hsm-signature_appearance.py
+++ b/examples/pdf-sign-cms-hsm-signature_appearance.py
@@ -5,6 +5,7 @@ from endesive import pdf, hsm
 
 import os
 import sys
+import sysconfig
 import datetime
 
 os.environ['SOFTHSM2_CONF'] = 'softhsm2.conf'
@@ -28,7 +29,7 @@ if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2')):
 if sys.platform == 'win32':
     dllpath = r'W:\binw\SoftHSM2\lib\softhsm2-x64.dll'
 else:
-    dllpath = '/usr/lib/softhsm/libsofthsm2.so'
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 import PyKCS11 as PK11
 

--- a/examples/pdf-sign-cms-hsm-signature_manual.py
+++ b/examples/pdf-sign-cms-hsm-signature_manual.py
@@ -5,6 +5,7 @@ from endesive import pdf, hsm
 
 import os
 import sys
+import sysconfig
 import datetime
 
 os.environ['SOFTHSM2_CONF'] = 'softhsm2.conf'
@@ -28,7 +29,7 @@ if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2')):
 if sys.platform == 'win32':
     dllpath = r'W:\binw\SoftHSM2\lib\softhsm2-x64.dll'
 else:
-    dllpath = '/usr/lib/softhsm/libsofthsm2.so'
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 import PyKCS11 as PK11
 

--- a/examples/pdf-sign-cms-hsm.py
+++ b/examples/pdf-sign-cms-hsm.py
@@ -5,6 +5,7 @@ from endesive import pdf, hsm
 
 import os
 import sys
+import sysconfig
 import datetime
 from cryptography import x509
 from cryptography.hazmat import backends
@@ -30,7 +31,7 @@ if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2')):
 if sys.platform == 'win32':
     dllpath = r'W:\binw\SoftHSM2\lib\softhsm2-x64.dll'
 else:
-    dllpath = '/usr/lib/softhsm/libsofthsm2.so'
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 import PyKCS11 as PK11
 

--- a/examples/pdf-verify-hsm.py
+++ b/examples/pdf-verify-hsm.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import sysconfig
 
 os.environ['SOFTHSM2_CONF'] = 'softhsm2.conf'
 if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2.conf')):
@@ -25,7 +26,7 @@ if not os.path.exists(os.path.join(os.getcwd(), 'softhsm2')):
 if sys.platform == 'win32':
     dllpath = r'W:\binw\SoftHSM2\lib\softhsm2-x64.dll'
 else:
-    dllpath = '/usr/lib/softhsm/libsofthsm2.so'
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 from endesive import hsm, pdf
 import PyKCS11 as PK11

--- a/examples/xml-hsm-softhsm2-enveloped.py
+++ b/examples/xml-hsm-softhsm2-enveloped.py
@@ -9,12 +9,13 @@ from endesive import xades, signer, hsm
 
 import os
 import sys
+import sysconfig
 
 os.environ["SOFTHSM2_CONF"] = "softhsm2.conf"
 if sys.platform == "win32":
     dllpath = r"W:\binw\SoftHSM2\lib\softhsm2-x64.dll"
 else:
-    dllpath = "/usr/lib/softhsm/libsofthsm2.so"
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 import PyKCS11 as PK11
 

--- a/examples/xml-hsm-softhsm2-enveloping.py
+++ b/examples/xml-hsm-softhsm2-enveloping.py
@@ -9,12 +9,13 @@ from endesive import xades, signer, hsm
 
 import os
 import sys
+import sysconfig
 
 os.environ["SOFTHSM2_CONF"] = "softhsm2.conf"
 if sys.platform == "win32":
     dllpath = r"W:\binw\SoftHSM2\lib\softhsm2-x64.dll"
 else:
-    dllpath = "/usr/lib/softhsm/libsofthsm2.so"
+    dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), "softhsm/libsofthsm2.so")
 
 import PyKCS11 as PK11
 

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import stat
 import subprocess
+import sysconfig
 import datetime
 import base64
 import email
@@ -28,7 +29,7 @@ fixtures_dir = os.path.join(tests_root, 'fixtures')
 def fixture(fname):
     return os.path.join(fixtures_dir, fname)
 
-dllpath = '/usr/lib/softhsm/libsofthsm2.so'
+dllpath = os.path.join(sysconfig.get_config_var('LIBDIR'), 'softhsm/libsofthsm2.so')
 
 os.makedirs(os.path.join(fixtures_dir, 'softhsm2'), exist_ok=True)
 os.environ['SOFTHSM2_CONF'] = fixture('softhsm2.conf')


### PR DESCRIPTION
Some Linux distributions like Gentoo install shared object files into `/usr/lib64` instead of `/usr/lib`. Library paths shouldn't be hardcoded, but the `sysconfig` module should be used instead.