### PR TITLE
fix test case for OpenSSL 3

### DIFF
--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -86,7 +86,9 @@ class EMAILTests(unittest.TestCase):
         process = Popen(cmd, stdout=PIPE, stderr=PIPE)
         stdout, stderr = process.communicate()
 
-        assert stderr == b'Verification successful\n'
+        # OpenSSL <= 1.1.1 outputs 'Verification successful'
+        # OpenSSL >= 3.0.0 outputs 'CMS Verification successful'
+        assert stderr == b'Verification successful\n' or stderr == b'CMS Verification successful\n'
         assert datau.replace(b'\n', b'\r\n') == stdout
 
     def test_email_signed_attr_custom(self):


### PR DESCRIPTION
From OpenSSL 3 on, `openssl cms -verify` outputs `CMS Verification successful` instead of `Verification successful`. Thus the test cases have to cope with both variants.