### PR TITLE
Support for elliptic curve private keys

### DIFF
--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -10,6 +10,7 @@ import codecs
 import struct
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.hazmat.primitives.asymmetric import ec
 from endesive import signer
 from endesive.pdf.PyPDF2 import pdf, generic as po
 
@@ -660,7 +661,7 @@ class SignedData(pdf.PdfFileWriter):
             algomd = obj["/DigestMethod"][1:].lower()
 
         # produce smaller signatures, but must be signed twice
-        aligned = udct.get("aligned", 0)
+        aligned = udct.get("aligned", 4096 if isinstance(key, ec.EllipticCurvePrivateKey) else 0)
         if aligned:
             zeros = b"00" * aligned
         else:

--- a/endesive/signer.py
+++ b/endesive/signer.py
@@ -14,7 +14,7 @@ from asn1crypto import cms, algos, core, keys, pem, tsp, x509, ocsp, util
 from oscrypto import asymmetric
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding, utils
+from cryptography.hazmat.primitives.asymmetric import padding, utils, ec
 
 
 def cert2asn(cert, cert_bytes=True):
@@ -354,9 +354,14 @@ def sign(
                 utils.Prehashed(hashes.SHA512()),
             )
         else:
-            signed_value_signature = key.sign(
-                tosign, padding.PKCS1v15(), getattr(hashes, hashalgo.upper())()
-            )
+            if isinstance(key, ec.EllipticCurvePrivateKey):
+                signed_value_signature = key.sign(
+                    tosign, ec.ECDSA(getattr(hashes, hashalgo.upper())())
+                )
+            else:
+                signed_value_signature = key.sign(
+                    tosign, padding.PKCS1v15(), getattr(hashes, hashalgo.upper())()
+                )
 
     if timestampurl is not None:
         datas["content"]["signer_infos"][0]["unsigned_attrs"] = timestamp(

--- a/endesive/verifier.py
+++ b/endesive/verifier.py
@@ -7,7 +7,7 @@ from asn1crypto import x509, core, pem, cms
 from certvalidator import CertificateValidator, ValidationContext
 
 from cryptography.hazmat.primitives import serialization, hashes
-from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import padding, ec
 from cryptography import x509 as cx509
 from cryptography.hazmat.backends import default_backend
 
@@ -67,7 +67,17 @@ class VerifyData(object):
         sigalgo = signed_data["signer_infos"][0]["signature_algorithm"]
         # sigalgo.debug()
         sigalgoname = sigalgo.signature_algo
-        if sigalgoname == "rsassa_pss":
+        if isinstance(public_key, ec.EllipticCurvePublicKey):
+            try:
+                public_key.verify(
+                    signature,
+                    signedData,
+                    ec.ECDSA(getattr(hashes, algo.upper())()),
+                )
+                signatureok = True
+            except Exception as e:
+                signatureok = False
+        elif sigalgoname == "rsassa_pss":
             parameters = sigalgo["parameters"]
             # parameters.debug()
             # print(parameters.native)

--- a/tests/fixtures/.gitignore
+++ b/tests/fixtures/.gitignore
@@ -5,6 +5,7 @@ softhsm2.conf
 pdf-signed-cms.pdf
 pdf-encrypted-signed.pdf
 pdf-signed-appearance.pdf
+pdf-signed-appearance-ec.pdf
 pdf-signed-cms-aligned.pdf
 plain-signed-attr.txt
 plain-signed-noattr.txt

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -161,6 +161,52 @@ class PDFTests(unittest.TestCase):
         for (hashok, signatureok, certok) in results:
             assert signatureok and hashok and certok
 
+    def test_pdf_signature_appearance_ec(self):
+        dct = {
+            'aligned': 0,
+            'sigflags': 3,
+            'sigflagsft': 132,
+            'sigpage': 0,
+            'sigbutton': False,
+            'sigfield': 'Signature-1667820612.078739',
+            'auto_sigfield': False,
+            'sigandcertify': False,
+            'signaturebox': [175.79446979865773, 294.7236779911374, 447.47683221476507, 573.2810782865583],
+            'contact': '',
+            'location': '',
+            'reason': '',
+            'signingdate': "D:20221107123012+00'00'",
+            'signature_appearance': {
+                'background': [0.75, 0.8, 0.95],
+                'outline': [0.2, 0.3, 0.5],
+                'border': 1,
+                'labels': True,
+                'display': ['date']
+            }
+        }
+        p12 = test_cert.CA().pk12_load(test_cert.cert3_p12, '1234')
+        fname = fixture('pdf.pdf')
+        with open(fname, 'rb') as fh:
+            datau = fh.read()
+        datas = pdf.cms.sign(datau, dct,
+            p12[0], p12[1], p12[2],
+            'sha256'
+        )
+        fname = fname.replace('.pdf', '-signed-appearance-ec.pdf')
+        with open(fname, 'wb') as fp:
+            fp.write(datau)
+            fp.write(datas)
+
+        with open(test_cert.ca_cert, 'rb') as fh:
+            trusted_cert_pems = (fh.read(),)
+        with open(fname, 'rb') as fh:
+            data = fh.read()
+        results = pdf.verify(
+            data, trusted_cert_pems, "/etc/ssl/certs"
+        )
+        for (hashok, signatureok, certok) in results:
+            assert signatureok and hashok and certok
+
     def test_pdf_signature_manual(self):
         date = datetime.datetime.utcnow() - datetime.timedelta(hours=12)
         date = date.strftime('D:%Y%m%d%H%M%S+00\'00\'')

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -163,7 +163,7 @@ class PDFTests(unittest.TestCase):
 
     def test_pdf_signature_appearance_ec(self):
         dct = {
-            'aligned': 0,
+            'aligned': 4096,
             'sigflags': 3,
             'sigflagsft': 132,
             'sigpage': 0,


### PR DESCRIPTION
Currently, when trying to use a elliptic curve key to sign a PDF, the following error appears:
```
  File "/home/georg/.local/lib/python3.10/site-packages/endesive/pdf/cms.py", line 990, in sign
    return cls.sign(
  File "/home/georg/.local/lib/python3.10/site-packages/endesive/pdf/cms.py", line 679, in sign
    contents = signer.sign(
  File "/home/georg/.local/lib/python3.10/site-packages/endesive/signer.py", line 360, in sign
    signed_value_signature = key.sign(
TypeError: _EllipticCurvePrivateKey.sign() takes 3 positional arguments but 4 were given
```

This change adds support for elliptic curve private keys. It works in general but sometimes (using the same certificate, PDF file and code) the following error appears:
```
Traceback (most recent call last):
  File "/home/georg/.local/lib/python3.10/site-packages/endesive/pdf/cms.py", line 990, in sign
    return cls.sign(
  File "/home/georg/.local/lib/python3.10/site-packages/endesive/pdf/cms.py", line 782, in sign
    assert len(zeros) == len(contents)
AssertionError
```

I'm not sure where the problem is here. My guess is that it is something related with the timestamp used for signing. Maybe you can help with this issue?