### PR TITLE
add support for signing with RSASSA-PSS private keys stored in HSM

### DIFF
--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -660,6 +660,8 @@ class SignedData(pdf.PdfFileWriter):
         if obj is not None:
             algomd = obj["/DigestMethod"][1:].lower()
 
+        pss = udct.get("force_pss", False)
+
         # produce smaller signatures, but must be signed twice
         aligned = udct.get("aligned", 4096 if isinstance(key, ec.EllipticCurvePrivateKey) else 0)
         if aligned:
@@ -686,7 +688,7 @@ class SignedData(pdf.PdfFileWriter):
                     attrs,
                     md,
                     hsm,
-                    False,
+                    pss,
                     timestampurl,
                     timestampcredentials,
                     timestamp_req_options,
@@ -769,7 +771,7 @@ class SignedData(pdf.PdfFileWriter):
                 attrs,
                 md,
                 hsm,
-                False,
+                pss,
                 timestampurl,
                 timestampcredentials,
                 timestamp_req_options,
@@ -921,6 +923,9 @@ def sign(
             text: dict                  text attributes
                                             wraptext=True, fontsize:12, textalign:'left', linespacing:1.2
             application: string         optional application name in advanced signature properties dialog in Acrobat Reader
+            force_pss: bool default:False
+                                                True  - do a RSASSA-PSS signature
+                                                False - do a RSASSA-PKCS-v1.5 signature
         key: cryptography.hazmat.backends.openssl.rsa._RSAPrivateKey - private key used to sign the document
         cert: cryptography.x509.Certificate - certificate associated with the key
         othercerts: list of cryptography.x509.Certificate to be saved with the signed document,

--- a/endesive/signer.py
+++ b/endesive/signer.py
@@ -151,8 +151,11 @@ def sign(
             {"algorithm": "rsassa_pkcs1v15"}
         )
     else:
-        if isinstance(key, keys.PrivateKeyInfo):
-            salt_length = key.byte_size - hashes.SHA512.digest_size - 2
+        signature_algorithm_hash_algorithm = "sha512"
+        if hsm is not None:
+            salt_length = getattr(hashes, hashalgo.upper()).digest_size
+            signature_algorithm_hash_algorithm = hashalgo
+        elif isinstance(key, keys.PrivateKeyInfo):
             salt_length = hashes.SHA512.digest_size
         else:
             salt_length = padding.calculate_max_pss_salt_length(key, hashes.SHA512)
@@ -162,13 +165,13 @@ def sign(
                 "parameters": algos.RSASSAPSSParams(
                     {
                         "hash_algorithm": algos.DigestAlgorithm(
-                            {"algorithm": "sha512"}
+                            {"algorithm": signature_algorithm_hash_algorithm}
                         ),
                         "mask_gen_algorithm": algos.MaskGenAlgorithm(
                             {
                                 "algorithm": algos.MaskGenAlgorithmId("mgf1"),
                                 "parameters": {
-                                    "algorithm": algos.DigestAlgorithmId("sha512"),
+                                    "algorithm": algos.DigestAlgorithmId(signature_algorithm_hash_algorithm),
                                 },
                             }
                         ),


### PR DESCRIPTION
Currently, when trying to use a RSASSA-PSS private key stored in a Google Cloud KMS HSM to sign a PDF, the obtained signature is not valid.

See #161 for my adventures in that domain.

This is because in signer.sign() the **pss** parameter is always False when called from cms, and some fields in the SignedDigestAlgorithm are hardcoded to sha512 algo.

This change :

- Adds a "force_pss" udct signing parameter, a boolean with default False
- In signer.sign() when pss is True and hsm is not None, use hashalgo to find salt_length and as "algorithm" in SignedDigestAlgorithm fields

This change does not modify the behavior of any other case, for example signer.sign(), plain.sign() or email.sign() with pss is True and hsm is None.


Tested with a "Google Cloud KMS HSM Asymmetric sign RSASSA-PSS 2048 bit key with a SHA-256 digest" (see https://cloud.google.com/kms/docs/algorithms).


Please advise if anything must/can be improved, will gladly work on that. Looking forward to be able to be able to push that upstream ! :)

Cheers, 
JB.