### PR TITLE
Use signing date by default

### DIFF
--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -659,6 +659,7 @@ class SignedData(pdf.PdfFileWriter):
         mode="sign",
         ocspurl=None,
         ocspissuer=None,
+        use_signingdate=True,
     ):
         startdata = len(datau)
 
@@ -721,7 +722,7 @@ class SignedData(pdf.PdfFileWriter):
                 )
             zeros = contents.hex().encode("utf-8")
 
-        params = {"mode": mode}
+        params = {"mode": mode, "use_signingdate": use_signingdate}
         if not timestampurl:
             params["use_signingdate"] = True
 


### PR DESCRIPTION
## Summary

Endesive tries to enforce a contradicting ISO 32000-1 requirement
regarding the presence or absense of signing time metadata while
generating a PAdES signature. This results in a signed pdf that
does not conform with PAdES, ETSI EN 319 142-1, the european standard
for PDF signatures.

This PR enables signing time metadata by default.

## Details

ETSI EN 319 142-1:
  Electronic Signatures and Infrastructures (ESI); PAdES digital signatures;

  PAdES signatures build on PDF signatures specified in ISO 32000-1
  with an alternative signature encoding to support digital signature formats
  equivalent to the signature format CAdES as specified in ETSI EN 319 122-1


ETSI EN 319 122-1:
  Electronic Signatures and Infrastructures (ESI); CAdES digital signatures;

  CAdES signatures are built on CMS signatures
  [defined in IETF RFC 5652 (2009): "Cryptographic Message Syntax (CMS)"]


IETF RFC 5652 (2009):
   Cryptographic Message Syntax (CMS)

   This syntax is used to digitally sign, digest, authenticate, or encrypt
   arbitrary message content.


ISO 32000-1:
   Portable Document Format, PDF 1.7


Digital PDF signatures are defined in ISO 32000-1, Section 12.8.
Some of the metadata within a PDF digital signature structure are:

- The range of the file contents protected by the signature (/ByteRange)
  This excludes the actual cryptographic content of the signature itself.

- The type of handler that must be used to verify the signature (/Filter)
  This is usually fixed as "Adobe.PPKLite"

- The format of the cryptographic content of the signature (/SubFilter)
  ISO 32000-1 defines formats:
  - "adbe.x509.rsa_sha1" for PKCS#1 signatures
  - "adbe.pkcs7.sha1" for PKCS#7 signatures
  - "adbe.pkcs7.detached" for PKCS#7 signatures in an optimized format.
    This is the most commonly used format above.

  PAdES extends ISO 32000-1 defining the following cryptographic format:
  - "ETSI.CAdES.detached", an optimized CMS format defined in CAdES

- The actual cryptographic content of the signature (/Contents)

- The time that the document was signed (/M)
  This is where the issue is found.

ISO 32000-1 defines that signature time (/M) is generally optional but:

A. If an ISO 32000-1 "adbe.pkcs7.*" signature format contains a secure
   timestamap in it, then the timestamp metadata (/M) in the PDF file
   must NEVER be set, it must be missing.

B. However, a PAdES requires a "ETSI.CAdES.detached" format and that
   the timestamp metadata (/M) must ALWAYS be set, it cannot be missing,
   whether there is a timestamp within the cryptographic content or not.

Presumably trying to conform with A. ISO 32000-1, the python package
'endesive' included a check in endesive/pdf/cms.py to remove the
timestamp metadata:

  commit 2bbbcf81ec3d2c27200449a285dfc39a0474402b
  Author: Seneca Cunningham <seneca@vybenetworks.com>
  Date:   Sat Mar 13 10:37:55 2021 -0500
  
      Only include /M if a timestamp server is not used

However, PAdES requires B as defined in:

  Table 1: Requirements on the main attributes for PAdES baseline signatures

  The service "protection of signing certificate" "shall be provided"
  in all cases.

  Part of this mandatory service is the option: "entry with the key M in
  the Signature Dictionary" which "shall be present" in all cases.

Therefore, the cms module that generates ETSI.CAdES.detached signatures as
required by PAdES should always include the timestamp metadata.

## Test

This PR was tested using https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo/validation:

1. When this change is not included, validation shows the following:
```
Signature format:    PDF-NOT-ETSI
AdES Validation Details:
        The certificate chain for signature is not trusted, it does not contain a trust anchor.
        The signed qualifying property: 'signing-time' is not present!
```
2. When this change is applied:
```
Signature format:    PAdES-BASELINE-T
AdES Validation Details:
        The certificate chain for signature is not trusted, it does not contain a trust anchor.
```
