### PR TITLE
Custom signature text

### DIFF
--- a/endesive/pdf/PyPDF2_annotate/annotations/signature.py
+++ b/endesive/pdf/PyPDF2_annotate/annotations/signature.py
@@ -97,24 +97,27 @@ class Signature(Annotation):
         t_top = 5
         border = signature.get('border', 0)
 
-        if signature.get('labels', False):
-            labels = dict(
-                DN = 'DN: ',
-                CN = 'Digitally signed by ',
-                date = 'Date: ',
-                contact = 'Contact: ',
-                reason = 'Reason: ',
-                location = 'Location: ',
-                software = 'Signing software: ',
-                )
-        else:
-            labels = {}
-
         block = []
-        for i in ('CN', 'DN', 'date', 'reason', 'contact', 'location', 'software'):
-            if i not in signature:
-                continue
-            block.append('{}{}'.format(labels.get(i, ''), signature[i]))
+        if signature.get('text', False):
+            block.append(signature['text'])
+        else:
+            if signature.get('labels', False):
+                labels = dict(
+                    DN = 'DN: ',
+                    CN = 'Digitally signed by ',
+                    date = 'Date: ',
+                    contact = 'Contact: ',
+                    reason = 'Reason: ',
+                    location = 'Location: ',
+                    software = 'Signing software: ',
+                )
+            else:
+                labels = {}
+
+            for i in ('CN', 'DN', 'date', 'reason', 'contact', 'location', 'software'):
+                if i not in signature:
+                    continue
+                block.append('{}{}'.format(labels.get(i, ''), signature[i]))
 
         cs = ContentStream([Save()])
         if 'background' in signature:

--- a/endesive/pdf/cms.py
+++ b/endesive/pdf/cms.py
@@ -343,19 +343,21 @@ class SignedData(pdf.PdfFileWriter):
                     sig[f] = udct["signature_appearance"][f]
 
             toggles = udct["signature_appearance"].get("display", [])
-            for f in ("contact", "reason", "location", "contact", "signingdate"):
-                if f in toggles:
-                    sig[f] = udct.get(f, "{} unknown".format(f))
-            if "date" in toggles:
-                sig["date"] = udct["signingdate"]
-            if "CN" in toggles:
-                from cryptography.x509 import ObjectIdentifier
-
-                sig["CN"] = cert.subject.get_attributes_for_oid(
-                    ObjectIdentifier("2.5.4.3")
-                )[0].value
-            if "DN" in toggles:
-                sig["DN"] = cert.subject.rfc4514_string()
+            if(isinstance(toggles, str)):
+                sig["text"] = toggles
+            else:
+                for f in ("contact", "reason", "location", "contact", "signingdate"):
+                    if f in toggles:
+                        sig[f] = udct.get(f, "{} unknown".format(f))
+                if "date" in toggles:
+                    sig["date"] = udct["signingdate"]
+                if "CN" in toggles:
+                    from cryptography.x509 import ObjectIdentifier
+                    sig["CN"] = cert.subject.get_attributes_for_oid(
+                        ObjectIdentifier("2.5.4.3")
+                    )[0].value
+                if "DN" in toggles:
+                    sig["DN"] = cert.subject.rfc4514_string()
             annotation.simple_signature(sig)
         else:
             # Manual signature annotation creation


### PR DESCRIPTION
This change adds the option to display a custom signature text. This is useful if you e.g. want to use translated text, a custom date format or if you have certificates without a common name (display the email instead).

Usage: if you pass a string instead of a dict as "display" in the "signature_appearance" dict, this exact text will be used. The functionality stays the same as before if you pass a dict as "display".

```
dct['signature_appearance'] = {
	'background': [0.75, 0.8, 0.95],
	'outline': [0.2, 0.3, 0.5],
	'border': 1,
	'labels': True,
	'display': 'Custom Line 1\nCustom Line 2', # custom text
	#'display': ['CN', 'date'], # it is still possible to use it like before
}
```